### PR TITLE
* Fix the debugger for newer R versions

### DIFF
--- a/src/RInternals/InternalContext.h
+++ b/src/RInternals/InternalContext.h
@@ -136,6 +136,40 @@ struct RInternalStructures_4_0 {
     int bcintactive;
     SEXP bcbody;
     void* bcpc;
+    SEXP handlerstack;
+    SEXP restartstack;
+    struct RPRSTACK *prstack;
+    void *nodestack;
+    void *bcprottop;
+    SEXP srcref;
+    int browserfinish;
+    SEXP returnValue;
+    struct RCNTXT *jumptarget;
+    int jumpmask;
+  };
+};
+
+struct RInternalStructures_4_4 {
+  struct RCNTXT {
+    struct RCNTXT *nextcontext;
+    int callflag;
+    JMP_BUF cjmpbuf;
+    int cstacktop;
+    int evaldepth;
+    SEXP promargs;
+    SEXP callfun;
+    SEXP sysparent;
+    SEXP call;
+    SEXP cloenv;
+    SEXP conexit;
+    void (*cend)(void *);
+    void *cenddata;
+    void *vmax;
+    int intsusp;
+    int gcenabled;
+    int bcintactive;
+    SEXP bcbody;
+    void* bcpc;
     ptrdiff_t relpc; // https://github.com/r-devel/r-svn/commit/59c821d19ff741a06d0e4cea7fad9aff904eeab4
     SEXP handlerstack;
     SEXP restartstack;

--- a/src/RInternals/InternalContext.h
+++ b/src/RInternals/InternalContext.h
@@ -136,11 +136,13 @@ struct RInternalStructures_4_0 {
     int bcintactive;
     SEXP bcbody;
     void* bcpc;
+    ptrdiff_t relpc; // https://github.com/r-devel/r-svn/commit/59c821d19ff741a06d0e4cea7fad9aff904eeab4
     SEXP handlerstack;
     SEXP restartstack;
     struct RPRSTACK *prstack;
     void *nodestack;
     void *bcprottop;
+    void *bcframe; // https://github.com/r-devel/r-svn/commit/2d0a210cff318506404263f9a4814064135a686a
     SEXP srcref;
     int browserfinish;
     SEXP returnValue;

--- a/src/RInternals/RInternals.cpp
+++ b/src/RInternals/RInternals.cpp
@@ -35,7 +35,8 @@ static int rVersion;
 #define SELECT(call, ...) \
   if (rVersion <= 33) return call<RInternalStructures_3_3>(__VA_ARGS__);\
   else if (rVersion < 40) return call<RInternalStructures_3_4>(__VA_ARGS__);\
-  else return call<RInternalStructures_4_0>(__VA_ARGS__)
+  else if (rVersion < 44) return call<RInternalStructures_4_0>(__VA_ARGS__);\
+  else return call<RInternalStructures_4_4>(__VA_ARGS__)
 
 bool isOldR() {
   return rVersion <= 33;

--- a/src/RPIServiceMethods.cpp
+++ b/src/RPIServiceMethods.cpp
@@ -221,7 +221,7 @@ Status RPIServiceImpl::saveGlobalEnvironment(ServerContext *context, const Strin
 
 Status RPIServiceImpl::loadEnvironment(ServerContext *context, const LoadEnvironmentRequest *request, Empty*) {
   executeOnMainThread([&] {
-    const string &variableName = request->variable();
+    const grpc::string &variableName = request->variable();
     if (variableName.empty()) {
       RI->sysLoadImage(request->file());
     } else {

--- a/src/RRefs.cpp
+++ b/src/RRefs.cpp
@@ -219,11 +219,11 @@ Status RPIServiceImpl::getLoadedShortS4ClassInfos(ServerContext* context, const 
 }
 
 struct SlotInfo {
-  string name, type, declarationClass;
+  grpc::string name, type, declarationClass;
 };
 
 std::vector<SlotInfo> extractSlots(const ShieldSEXP &classDef) {
-  std::unordered_map<string, SlotInfo> slotsInfos;
+  std::unordered_map<grpc::string, SlotInfo> slotsInfos;
   auto defProcessor = [&slotsInfos](const ShieldSEXP &classDef) {
     if (TYPEOF(classDef) != S4SXP) return;
     auto className = stringEltUTF8(R_do_slot(classDef, toSEXP("className")), 0);
@@ -240,7 +240,7 @@ std::vector<SlotInfo> extractSlots(const ShieldSEXP &classDef) {
   };
 
   ShieldSEXP superClassesList = R_do_slot(classDef, toSEXP("contains"));
-  std::vector<std::pair<int, string>> superClasses;
+  std::vector<std::pair<int, grpc::string>> superClasses;
   for (int i = 0; i < superClassesList.length(); ++i) {
     ShieldSEXP superClass = VECTOR_ELT(superClassesList, i);
     auto superClassName = stringEltUTF8(R_do_slot(superClass, toSEXP("superClass")), 0);
@@ -370,7 +370,7 @@ void getR6ClassInfo(const ShieldSEXP &classDef, R6ClassInfo *response) {
     for (int i = 0; i < methods.length(); ++i) {
         auto next_member = response->add_methods();
         next_member->set_name(stringEltUTF8(names, i));
-        string description = stringEltUTF8(methods, i);
+        grpc::string description = stringEltUTF8(methods, i);
         next_member->set_parameterlist(description.substr(strlen("function "), description.size() - 2));
         next_member->set_ispublic(true);
     }

--- a/src/RStuff/RUtil.h
+++ b/src/RStuff/RUtil.h
@@ -325,7 +325,9 @@ inline void walkObjectsImpl(Func const& f, std::unordered_set<SEXP> &visited, SE
     case DOTSXP:
     case LANGSXP:
     case LISTSXP: {
-      walkObjectsImpl(f, visited, CAR(x));
+      // sxpinfo.extra may contain an immediate binding, meaning that CAR(x) should not be called
+      // See: https://github.com/r-devel/r-svn/blob/trunk/doc/notes/immbnd.md
+      if (!x->sxpinfo.extra) walkObjectsImpl(f, visited, CAR(x));
       walkObjectsImpl(f, visited, CDR(x));
       walkObjectsImpl(f, visited, TAG(x));
       break;


### PR DESCRIPTION
The debugger in Rkernel will when activated walk all items in all loaded environments in R in order to register byte codes. When encountering a LISTSXP it will call CAR and CDR in order to traverse the list. However, R has since version 4 introduced immediate bindings, which means that calling CAR on certain LISTSXP is invalid as there is an immediate value that instead should be considered. This causes the "bad binding access" error when invoking the debugger.

This PR fixes that by:
* Avoid trying to traverse immediate bindings when walking objects

Further complications that came with immediate bindings are that two fields were added to RCNTXT, and them being missing in Rkernel causes segfaults when building the stack in the debugger. These fields appear to have been added to R in R 4.4.0.

This PR fixes that by:
* Add ptrdiff_t and bcframe to RCNTXT for R >= 4.4

The testing conducted this far has been R 4.4.1 on OSX, everything appears to work well and testing has been thorough. For R 4.3.1 on Linux, everything appears to work well during brief testing.