### PR TITLE
* Adaptations to work with R 4.5.0

### DIFF
--- a/src/DataFrame.cpp
+++ b/src/DataFrame.cpp
@@ -34,7 +34,7 @@ static bool initDplyr() {
 }
 
 bool isSupportedDataFrame(SEXP x) {
-  return Rf_isMatrix(x) || isDataFrame(x);
+  return Rf_isMatrix(x) || isDataFrameJb(x);
 }
 
 static PrSEXP& getDataFrameStorageEnv() {
@@ -73,7 +73,7 @@ static void initDataFrame(DataFrameInfo *info) {
   if (Rf_isMatrix(dataFrame)) {
     dataFrame = RI->dataFrame(dataFrame, named("stringsAsFactors", false));
   }
-  if (!isDataFrame(dataFrame)) {
+  if (!isDataFrameJb(dataFrame)) {
     RI->stop("Object is not a valid data frame");
   }
 

--- a/src/ExecuteCode.cpp
+++ b/src/ExecuteCode.cpp
@@ -259,10 +259,6 @@ static SEXP cloneSrcref(SEXP srcref) {
   return newSrcref;
 }
 
-extern "C" {
-void Rf_callToplevelHandlers(SEXP expr, SEXP value, Rboolean succeeded, Rboolean visible);
-}
-
 static void executeCodeImpl(SEXP _exprs, SEXP _env, bool withEcho, bool isDebug,
     bool withExceptionHandler, bool setLastValue, bool callToplevelHandlers) {
   ShieldSEXP exprs = _exprs;
@@ -310,10 +306,10 @@ static void executeCodeImpl(SEXP _exprs, SEXP _env, bool withEcho, bool isDebug,
         UNPROTECT(1);
       }
       if (setLastValue) {
-        SET_SYMVALUE(R_LastvalueSymbol, value);
+        Rf_defineVar(R_LastvalueSymbol, value, R_GlobalEnv);
       }
       if (callToplevelHandlers) {
-        Rf_callToplevelHandlers(exprs[i], value, TRUE, visible ? TRUE : FALSE);
+        RI->Rf_callToplevelHandlers(exprs[i], value, TRUE, visible ? TRUE : FALSE);
       }
       UNPROTECT(2);
       R_Srcref = R_NilValue;

--- a/src/ExecuteCode.cpp
+++ b/src/ExecuteCode.cpp
@@ -309,7 +309,7 @@ static void executeCodeImpl(SEXP _exprs, SEXP _env, bool withEcho, bool isDebug,
         Rf_defineVar(R_LastvalueSymbol, value, R_GlobalEnv);
       }
       if (callToplevelHandlers) {
-        RI->Rf_callToplevelHandlers(exprs[i], value, TRUE, visible ? TRUE : FALSE);
+        RI->Rf_callToplevelHandlersWrapper(exprs[i], value, TRUE, visible ? TRUE : FALSE);
       }
       UNPROTECT(2);
       R_Srcref = R_NilValue;

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -67,9 +67,7 @@ void quitRWrapper() {
 }
 
 extern "C" {
-typedef SEXP (*CCODE)(SEXP, SEXP, SEXP, SEXP);
-void SET_PRIMFUN(SEXP x, CCODE f);
-void R_CleanUp(SA_TYPE, int, int);
+  void R_CleanUp(SA_TYPE, int, int);
 }
 
 static void initColoredOutput() {
@@ -90,7 +88,7 @@ static void initColoredOutput() {
 }
 
 static void initDoQuit() {
-  SET_PRIMFUN(INTERNAL(Rf_install("quit")), [](SEXP call, SEXP op, SEXP args, SEXP rho) -> SEXP {
+  setFunTabFunction(getFunTabOffset("quit"), [](SEXP call, SEXP op, SEXP args, SEXP rho) -> SEXP {
     int argsCount = Rf_length(args);
     if (argsCount != 3) {
       Rf_error("%d arguments passed to .Internal(quit) which requires 3", argsCount);

--- a/src/RInternals/RInternals.h
+++ b/src/RInternals/RInternals.h
@@ -46,6 +46,22 @@ int getFunTabArity(int offset);
 FunTabFunction getFunTabFunction(int offset);
 void setFunTabFunction(int offset, FunTabFunction func);
 
+typedef Rboolean (*R_ToplevelCallback)(SEXP expr, SEXP value, Rboolean succeeded, Rboolean visible, void *);
+
+typedef struct _ToplevelCallback  R_ToplevelCallbackEl;
+/**
+ Linked list element for storing the top-level task callbacks.
+ */
+struct _ToplevelCallback {
+    R_ToplevelCallback cb; /* the C routine to call. */
+    void *data;            /* the user-level data to pass to the call to cb() */
+    void (*finalizer)(void *data); /* Called when the callback is removed. */
+
+    char *name;  /* a name by which to identify this element. */
+
+    R_ToplevelCallbackEl *next; /* the next element in the linked list. */
+};
+
 typedef SEXP (*R_UnwindProtect_t)
     (SEXP (*fun)(void *data), void *data, void (*cleanfun)(void *data, Rboolean jump), void *cleandata, SEXP cont);
 typedef void (*R_ContinueUnwind_t)(SEXP cont);

--- a/src/RInternals/RInternals.h
+++ b/src/RInternals/RInternals.h
@@ -46,22 +46,6 @@ int getFunTabArity(int offset);
 FunTabFunction getFunTabFunction(int offset);
 void setFunTabFunction(int offset, FunTabFunction func);
 
-typedef Rboolean (*R_ToplevelCallback)(SEXP expr, SEXP value, Rboolean succeeded, Rboolean visible, void *);
-
-typedef struct _ToplevelCallback  R_ToplevelCallbackEl;
-/**
- Linked list element for storing the top-level task callbacks.
- */
-struct _ToplevelCallback {
-    R_ToplevelCallback cb; /* the C routine to call. */
-    void *data;            /* the user-level data to pass to the call to cb() */
-    void (*finalizer)(void *data); /* Called when the callback is removed. */
-
-    char *name;  /* a name by which to identify this element. */
-
-    R_ToplevelCallbackEl *next; /* the next element in the linked list. */
-};
-
 typedef SEXP (*R_UnwindProtect_t)
     (SEXP (*fun)(void *data), void *data, void (*cleanfun)(void *data, Rboolean jump), void *cleandata, SEXP cont);
 typedef void (*R_ContinueUnwind_t)(SEXP cont);

--- a/src/RRefs.cpp
+++ b/src/RRefs.cpp
@@ -396,7 +396,7 @@ Status RPIServiceImpl::getR6ClassInfoByObjectName(ServerContext *context, const 
 Status RPIServiceImpl::getTableColumnsInfo(ServerContext* context, const TableColumnsInfoRequest* request, TableColumnsInfo* response) {
   executeOnMainThread([&] {
     ShieldSEXP table = dereference(request->ref());
-    if (!isDataFrame(table)) return;
+    if (!isDataFrameJb(table)) return;
     response->set_tabletype(
         Rf_inherits(table, "tbl_df") ? TableColumnsInfo_TableType_DPLYR :
         Rf_inherits(table, "data.table") ? TableColumnsInfo_TableType_DATA_TABLE :

--- a/src/RRefs.cpp
+++ b/src/RRefs.cpp
@@ -233,7 +233,7 @@ std::vector<SlotInfo> extractSlots(const ShieldSEXP &classDef) {
       auto slotName = stringEltUTF8(slotsNames, i);
       auto slotType = stringEltUTF8(VECTOR_ELT(slotsList, i), 0);
       if (slotsInfos.count(slotName) == 0 ||
-          R_extends(toSEXP(slotType), toSEXP(slotsInfos[slotName].type), RI->globalEnv) == TRUE) {
+          RI->R_extends(toSEXP(slotType), toSEXP(slotsInfos[slotName].type), RI->globalEnv) == TRUE) {
         slotsInfos[slotName] = {slotName, slotType, className};
       }
     }
@@ -289,7 +289,7 @@ Status RPIServiceImpl::getS4ClassInfoByObjectName(ServerContext* context, const 
     ShieldSEXP obj = dereference(*request);
     if (TYPEOF(obj) != S4SXP) return;
     ShieldSEXP className = Rf_getAttrib(obj, R_ClassSymbol);
-    getS4ClassInfo(R_getClassDef_R(className), response);
+    getS4ClassInfo(RI->R_getClassDef_R(className), response);
   }, context, true);
   return Status::OK;
 }

--- a/src/RStuff/Conversion.h
+++ b/src/RStuff/Conversion.h
@@ -98,7 +98,7 @@ inline bool asBool(SEXP x) {
 }
 
 inline bool isScalarString(SEXP x) { return TYPEOF(x) == STRSXP && Rf_xlength(x) == 1; }
-inline bool isDataFrame(SEXP x) { return TYPEOF(x) == VECSXP && Rf_inherits(x, "data.frame"); }
+//inline bool isDataFrame(SEXP x) { return TYPEOF(x) == VECSXP && Rf_inherits(x, "data.frame"); }
 
 const char* asStringUTF8OrError(SEXP x);
 int asIntOrError(SEXP x);

--- a/src/RStuff/Conversion.h
+++ b/src/RStuff/Conversion.h
@@ -98,7 +98,7 @@ inline bool asBool(SEXP x) {
 }
 
 inline bool isScalarString(SEXP x) { return TYPEOF(x) == STRSXP && Rf_xlength(x) == 1; }
-//inline bool isDataFrame(SEXP x) { return TYPEOF(x) == VECSXP && Rf_inherits(x, "data.frame"); }
+inline bool isDataFrameJb(SEXP x) { return TYPEOF(x) == VECSXP && Rf_inherits(x, "data.frame"); }
 
 const char* asStringUTF8OrError(SEXP x);
 int asIntOrError(SEXP x);

--- a/src/RStuff/RObjects.h
+++ b/src/RStuff/RObjects.h
@@ -25,6 +25,7 @@
 #include "../RInternals/RInternals.h"
 
 #if defined(_WIN32)
+	#define WIN32_LEAN_AND_MEAN
 	#include <windows.h>
 #else
 	#include <dlfcn.h>
@@ -200,9 +201,9 @@ struct RObjects2 {
   void Rf_callToplevelHandlersWrapper(SEXP expr, SEXP value, Rboolean succeeded, Rboolean visible) {
   	if (!callToplevelHandlers_set) {
 #if defined(_WIN32)
-  		HMODULE handle = GetModuleHandle(nullptr);
+  		HMODULE handle = GetModuleHandle("R.dll");
   		if (handle) {
-  			real_func = reinterpret_cast<FuncType>(
+  			callToplevelHandlers_ref = reinterpret_cast<callToplevelHandlers_type>(
 				  GetProcAddress(handle, "Rf_callToplevelHandlers"));
   		}
 #else

--- a/src/Subprocess.cpp
+++ b/src/Subprocess.cpp
@@ -25,11 +25,6 @@
 
 static const size_t BUF_SIZE = 4096;
 
-extern "C" {
-typedef SEXP (*CCODE)(SEXP, SEXP, SEXP, SEXP);
-void SET_PRIMFUN(SEXP x, CCODE f);
-}
-
 /**
  * consignals values are currently ignored, but they should be supported
  * see https://github.com/wch/r-source/commit/688f12cc9627c38ae10c4f597010da3f7142a487
@@ -137,7 +132,7 @@ DoSystemResult myDoSystemImpl(const char* cmd, int timeout,
 }
 
 void initDoSystem() {
-  SET_PRIMFUN(INTERNAL(Rf_install("system")), myDoSystem);
+  setFunTabFunction(getFunTabOffset("system"), myDoSystem);
 }
 
 void RPIServiceImpl::subprocessHandler(


### PR DESCRIPTION
R 4.5.0 added the attribute hidden to a lot of functions which are intended for internal R use only. Rkernel which wraps R to be able to provide the improved debug experience relies on some of these, namely:

- SET_PRIMFUN used to override C functions in the function table in R, easily replaced by setFunTabFunction
- SET_SYMVALUE used to set R variables, easily replaced by Rf_defineVar
- Rf_callToplevelHandlers used to call handles for a just evaluated top level expression. It has the comment /* This is not used in R and in no header */ which somehow hints at it being deprecated. It is now implemented in Rkernel if there is still any use in calling it.
- R_extends and R_getClassDef_R used to get info about classes in R. Unclear if the plugin still uses them as I was unable to get breakpoints to hit inside my new implementations. Can mostly be implemented in Rkernel to get something that works, some tricks must be made to determine if methods dispatch is enabled.

* Things to validate:
 - Does Rf_callToplevelHandlers work as intended? Mainly the commented part, otherwise the function is 1:1 from the internal R impl.
 - Are R_extends and R_getClassDef_R used, and if so, do they work as intended?